### PR TITLE
Remove inclusion of SRA accessions from pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ inputs/sourmash_databases/gtdb-rs207.taxonomy.csv.gz
 outputs/
 .snakemake
 download_links.txt
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -35,10 +35,9 @@ The database is available in [this OSF repository](https://osf.io/sndz5/).
 
 ## Adding new data to the database 
 
-Three files are used to determine which genomes are included in the final database:
+Two files are used to determine which genomes are included in the final database:
 
 * `inputs/genome_contaminants.csv`: Genome accessions for genomes to include in the database. Accessions are GenBank or RefSeq format (`GCF_*` or `GCA_*`). This Snakefile uses the `CDS_from_genomic.fna` files, so if a genome is missing this file, it cannot be included.
-* `inputs/seq_contaminants.csv`: SRA accessions (`SRR`, `ERR`, or `DRR`) for raw FASTQ files that capture genomes or transcriptomes for species to include in the database that don't have reference genomes in GenBank or RefSeq but have been sequenced.  
 * `inputs/doi10.1016j.tim.2018.11.003-table1.csv`: Genuses of bacteria or archaea that should be included in the database. To keep the final database small, one genome from each species under the specified genus is extracted from the GTDB database.
 
 The files in this repository reflect the genomes that were included in the database posted on OSF.

--- a/inputs/seq_contaminants.csv
+++ b/inputs/seq_contaminants.csv
@@ -1,6 +1,0 @@
-﻿ident,superkingdom,phylum,class,order,family,genus,species
-SRR1300406,d__Eukaryota,p__Cercozoa,c__Chlorarachniophyceae,,,g__Bigelowiella,s__Bigelowiella longifila
-SRR7504389,d__Eukaryota,p__Ciliophora,c__Colpodea,o__Colpodida,f__Colpodidae,g__Colpoda,s__Colpoda magna
-SRR8820545,d__Eukaryota,p__Chlorophyta,c__Chlorophyceae,o__Sphaeropleales,f__Selenastraceae,g__Bigelowiella,s__Selenastrum capricornutum
-ERR10375933,d__Eukaryota,p__Ciliophora,c__Oligohymenophorea,o__Hymenostomatida,f__Tetrahymenidae,g__Tetrahymena,s__Tetrahymena corlissi
-ERR10375938,d__Eukaryota,p__Ciliophora,c__Oligohymenophorea,o__Hymenostomatida,f__Tetrahymenidae,g__Tetrahymena,s__Tetrahymena vorax

--- a/scripts/snakemake_make_contam_db_taxonomy.R
+++ b/scripts/snakemake_make_contam_db_taxonomy.R
@@ -2,7 +2,6 @@ library(readr)
 library(dplyr)
 
 genomes <- read_csv(snakemake@input[['genome_taxonomy']])
-sra <- read_csv(snakemake@input[['sra_taxonomy']])
 phix <- data.frame(ident = 'GCF_000819615.1',
                    superkingdom = "d__Virus",
                    phylum = 'p__Phixviricota',
@@ -17,6 +16,6 @@ contams <- read_csv(snakemake@input[['picklist']]) %>%
 gtdb <- read_csv(snakemake@input[['gtdb_taxonomy']]) %>%
   filter(ident %in% contams$ident)
 
-taxonomy <- bind_rows(gtdb, sra, genomes, phix)
+taxonomy <- bind_rows(gtdb, genomes, phix)
 
 write_csv(taxonomy, snakemake@output[['taxonomy']])


### PR DESCRIPTION
As brought up in https://github.com/Arcadia-Science/seqqc/issues/14, it's probably not a good idea to include SRA accessions in the database. These raw sequencing files are highly likely to be contaminated themselves, so they become a catch-all match that isn't super informative. This PR rips them out. Once we have the genomeassembly pipeline up and going, I'd like to assemble these genomes ourselves and include them, but until then I think this pipeline is stronger removing them.